### PR TITLE
removed dependency and added installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ This adapter uses the [ecovacs-deebot.js](https://github.com/mrbungle64/ecovacs-
 * Deebot M88
 * Deebot 600/605
 
+## Installation
+
+This adapter uses the canvas library which might require additional installations, otherwise the installation in iobroker might result in an error:
+```
+npm ERR! canvas@2.6.1 install: node-pre-gyp install --fallback-to-build npm ERR! Exit status 1
+```
+For linux based systems the following commands should be executed:
+```
+sudo apt-get update
+sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+sudo npm install canvas --unsafe-perm=true
+```
+For instructions for other systems visit https://www.npmjs.com/package/canvas#compiling
+
 ## Usage
 
 * Information on how to use this adapter can be found [here](https://github.com/mrbungle64/ioBroker.ecovacs-deebot/wiki)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^1.0.3",
-    "canvas": "^2.6.1",
     "ecovacs-deebot": "^0.4.0",
     "node-machine-id": "^1.1.12"
   },


### PR DESCRIPTION
Removed canvas dependency as it is included in the library already and not directly used by the adapter (was just required as a temporary dev workaround).
Added installation instructions for canvas to README