### PR TITLE
add std test-and-release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,0 +1,92 @@
+name: Test and Release
+
+# Run this job on all pushes and pull requests
+# as well as tags with a semantic version
+on:
+    push:
+        branches:
+            - 'master'
+        tags:
+            # normal versions
+            - 'v[0-9]+.[0-9]+.[0-9]+'
+            # pre-releases
+            - 'v[0-9]+.[0-9]+.[0-9]+-**'
+    pull_request: {}
+
+# Cancel previous PR/branch runs when a new commit is pushed
+concurrency:
+    group: ${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    # Performs quick checks before the expensive test runs
+    check-and-lint:
+        if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: ioBroker/testing-action-check@v1
+              with:
+                  node-version: '18.x'
+                  # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+                  # install-command: 'npm install'
+                  lint: true
+
+    # Runs adapter tests on all supported node versions and OSes
+    adapter-tests:
+        if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                node-version: [16.x, 18.x, 20.x]
+                os: [ubuntu-latest, windows-latest, macos-latest]
+
+        steps:
+            - uses: ioBroker/testing-action-adapter@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  os: ${{ matrix.os }}
+                  # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+                  # install-command: 'npm install'
+
+    # TODO: To enable automatic npm releases, create a token on npmjs.org
+    # Enter this token as a GitHub secret (with name NPM_TOKEN) in the repository options
+    # Then uncomment the following block:
+
+    # Deploys the final package to NPM
+    deploy:
+        needs: [check-and-lint, adapter-tests]
+
+        # Trigger this step only when a commit on any branch is tagged with a version number
+        if: |
+            contains(github.event.head_commit.message, '[skip ci]') == false &&
+            github.event_name == 'push' &&
+            startsWith(github.ref, 'refs/tags/v')
+
+        runs-on: ubuntu-latest
+
+        # Write permissions are required to create Github releases
+        permissions:
+            contents: write
+
+        steps:
+            - uses: ioBroker/testing-action-deploy@v1
+              with:
+                  node-version: '18.x'
+                  # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+                  # install-command: 'npm install'
+                  npm-token: ${{ secrets.NPM_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+                  # When using Sentry for error reporting, Sentry can be informed about new releases
+                  # To enable create a API-Token in Sentry (User settings, API keys)
+                  # Enter this token as a GitHub secret (with name SENTRY_AUTH_TOKEN) in the repository options
+                  # Then uncomment and customize the following block:
+#          sentry: true
+#          sentry-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#          sentry-project: "iobroker-pid"
+#          sentry-version-prefix: "iobroker.pid"
+#          # If your sentry project is linked to a GitHub repository, you can enable the following option
+#          # sentry-github-integration: true


### PR DESCRIPTION
This PR adds the ioBroker standard test-and-release workflow.

Please merge into you setup.
Maybe this std workflow duplicates tests of nodejs.yml. So eventually you want to check / adapt / remove those workflows.

Although using the standard workflow is  NOT mandatory the tests contained in it (or equivalent tests) are mandatory for an adapter to be listed at the repositories. Usinf the standard workflow redudes work needed to check as at least partly an automatic check can be performed.

Thnaks for your cooperation adn eventually merging the PR.

And THANKS A LOT that you spend time for an ioBroker adapter and provide it to others,