### PR TITLE
Add DEEBOT T80S OMNI (rzwv5p) to model table

### DIFF
--- a/lib/deebotModel.js
+++ b/lib/deebotModel.js
@@ -654,6 +654,10 @@ const SUPPORTED_STATES = {
         "name": "DEEBOT T30S Pro Omni",
         "deviceClassLink": "3yqsch"
     },
+    "rzwv5p": {
+        "name": "DEEBOT T80S OMNI",
+        "deviceClassLink": "3yqsch"
+    },
     "9eamof": {
         "name": "DEEBOT T80 OMNI",
         "deviceClassLink": "3yqsch"


### PR DESCRIPTION
### Summary
Adds the **DEEBOT T80S OMNI** (`deviceClass rzwv5p`) to `lib/deebotModel.js`, linked to the same OMNI feature set as the existing T80 OMNI entries (`3yqsch`).

Without this entry the adapter falls back to defaults with the `map` feature disabled, so `map.currentMapName/Index/MID` are never created and `currentMapID` stays empty — which breaks the native per-room `cleanSpotArea` and the automatic spot-area fetch.

With it: map objects are created, `currentMapID` is set, per-room cleaning works and spot areas are fetched automatically.

Tested on a real DEEBOT T80S OMNI.

### Related
Library-side fixes (zstd map decoding, V2 spot-area events, model entry, water-level, and vector map SVG rendering) are in mrbungle64/ecovacs-deebot.js#592. Together they make spot areas, per-room cleaning and the map image work on the T80/T80S generation.

The map image is now solved: for these V2 devices the map is a vector floor plan from `getMapInfo_V2`, which the library decodes and emits as a `MapImageV2` message. In my fork the adapter listens for it and stores the result as `map.<mid>.mapSvg` plus a `map_<mid>.svg` file, so it can be shown directly in VIS. Tested live: all 12 rooms render with the correct names.

This PR stays limited to the minimal model-table entry. I am happy to open a follow-up PR for the adapter-side `MapImageV2` listener if you would like that upstream too.
