### PR TITLE
Store vector map SVG from getMapInfo_V2 (map.<mid>.mapSvg + file)

### DIFF
--- a/lib/adapterCommands.js
+++ b/lib/adapterCommands.js
@@ -217,6 +217,10 @@ async function handleStateChange(adapter, id, state) {
         if (stateName === 'loadCurrentMapImage') {
             adapter.log.info('Loading current map image');
             adapter.vacbot.run('GetMapImage', adapter.currentMapID, 'outline');
+            if (adapter.vacbot.is950type_V2 && adapter.vacbot.is950type_V2()) {
+                // Newer V2 devices deliver the map as a vector floor plan via getMapInfo_V2
+                adapter.vacbot.run('GetMapInfo_V2', adapter.currentMapID);
+            }
             return;
         }
 
@@ -271,6 +275,10 @@ async function handleStateChange(adapter, id, state) {
         if (stateName === 'loadMapImage') {
             adapter.log.info('Loading map image');
             adapter.vacbot.run('GetMapImage', mapID, 'outline');
+            if (adapter.vacbot.is950type_V2 && adapter.vacbot.is950type_V2()) {
+                // Newer V2 devices deliver the map as a vector floor plan via getMapInfo_V2
+                adapter.vacbot.run('GetMapInfo_V2', mapID);
+            }
             return;
         }
         if ((parseInt(state.val) > 0) && (adapter.currentMapID === mapID) && (adapter.currentSpotAreaID === mapSpotAreaID)) {

--- a/main.js
+++ b/main.js
@@ -846,6 +846,23 @@ class EcovacsDeebot extends utils.Adapter {
                         })();
                     });
 
+                    this.vacbot.on('MapImageV2', (object) => {
+                        if (object && object['svg'] && object['mapID']) {
+                            this.createObjectNotExists(
+                                'map.' + object['mapID'] + '.mapSvg', 'Map as SVG (vector floor plan)',
+                                'string', 'value', false, '', '').then(() => {
+                                this.setStateConditional('map.' + object['mapID'] + '.mapSvg', object['svg'], true);
+                            });
+                            (async () => {
+                                try {
+                                    await this.writeFileAsync(this.namespace, 'map_' + object['mapID'] + '.svg', Buffer.from(object['svg']));
+                                } catch (e) {
+                                    this.log.debug('Could not write map svg file: ' + e.message);
+                                }
+                            })();
+                        }
+                    });
+
                     this.vacbot.on('CurrentCustomAreaValues', (values) => {
                         if (((this.cleanstatus === 'custom_area') && (values !== '')) || (this.cleanstatus !== 'custom_area')) {
                             this.setStateConditional('map.currentUsedCustomAreaValues', values, true);


### PR DESCRIPTION
### Summary
Adapter-side support for the vector map on newer `950type_V2` devices (e.g. DEEBOT T80/T80S OMNI).

These devices no longer send a raster map picture. The active map is a vector floor plan returned by `getMapInfo_V2`. With the matching library change (ecovacs-deebot.js#592), the library decodes it and emits a `MapImageV2` message. This PR makes the adapter:

- request `GetMapInfo_V2` for `950type_V2` devices on `loadMapImage` / `loadCurrentMapImage` (next to the existing `GetMapImage` call), and
- on `MapImageV2`, store the SVG as `map.<mid>.mapSvg` and write a `map_<mid>.svg` file, so it can be shown directly (for example an `<img>` in VIS).

Non-V2 devices are unaffected: the extra command is only sent when `vacbot.is950type_V2()` is true, and the listener only acts when an SVG is present.

### Depends on
Library-side rendering in **mrbungle64/ecovacs-deebot.js#592** (it emits the `MapImageV2` message and adds `library/mapImageV2.js`). This adapter PR is a no-op without a library version that includes it.

### Tested
Live on a real DEEBOT T80S OMNI: pressing `map.<mid>.loadMapImage` produces `map.<mid>.mapSvg` and the `map_<mid>.svg` file, with all 12 rooms rendered and correctly named.

### Note
Kept intentionally small and independent from the `rzwv5p` model-table entry in #843.
